### PR TITLE
Added SixLabors.ImageSharp in order to remove warnings

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.8.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
 

--- a/Application/Services/PictureService.cs
+++ b/Application/Services/PictureService.cs
@@ -2,7 +2,7 @@
 using Core.Interfaces.Repositories;
 using Core.Interfaces.Services;
 using Microsoft.Extensions.Logging;
-using System.Drawing;
+using SixLabors.ImageSharp;
 
 namespace Application.Services
 {
@@ -65,7 +65,7 @@ namespace Application.Services
 
             using (MemoryStream ms = new(bytes))
             {
-                var image = Image.FromStream(ms);
+                var image = Image.Load(ms);
                 string profilePictureLink = await _pictureRepository.UploadAsync(image, blobFolder, identifier);
 
                 return profilePictureLink;

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
 </Project>

--- a/Core/Interfaces/Repositories/IPictureRepository.cs
+++ b/Core/Interfaces/Repositories/IPictureRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using SixLabors.ImageSharp;
 
 namespace Core.Interfaces.Repositories
 {

--- a/DataAccess/Repositories/PictureRepository.cs
+++ b/DataAccess/Repositories/PictureRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Azure.Storage.Blobs;
 using Core.Interfaces.Repositories;
 using Microsoft.Extensions.Configuration;
-using System.Drawing;
+using SixLabors.ImageSharp;
 
 namespace DataAccess.Repositories
 {
@@ -34,7 +34,7 @@ namespace DataAccess.Repositories
 
             using (MemoryStream ms = new())
             {
-                image.Save(ms, image.RawFormat);
+                image.SaveAsJpeg(ms);
                 ms.Position = 0;
 
                 await _blobContainerClient.UploadBlobAsync(fileName, ms);

--- a/Tests/Application.Tests/Application.Tests.csproj
+++ b/Tests/Application.Tests/Application.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Application.Tests/PictureServiceTests.cs
+++ b/Tests/Application.Tests/PictureServiceTests.cs
@@ -2,7 +2,7 @@
 using Azure;
 using FluentAssertions;
 using Moq;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using Xunit;
 
 namespace Application.Tests


### PR DESCRIPTION
Added SixLabors.ImageSharp in order to remove System.Drawing.Image windows-only warnings